### PR TITLE
Just Changed forwardmessage To CopyMessage

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -20,7 +20,7 @@ if (isset($update["message"])) {
                 $msg_param_s = explode("_", $message_params[1]);
                 $req_message_id = $msg_param_s[1];
                 try {
-                    $bot->api->forwardMessage(array(
+                    $bot->api->CopyMessage(array(
                         "chat_id" => $chat_id,
                         "from_chat_id" => $GLOBALS["TG_DUMP_CHANNEL_ID"],
                         "disable_notification" => True,

--- a/web/index.php
+++ b/web/index.php
@@ -20,7 +20,7 @@ if (isset($update["message"])) {
                 $msg_param_s = explode("_", $message_params[1]);
                 $req_message_id = $msg_param_s[1];
                 try {
-                    $bot->api->CopyMessage(array(
+                    $bot->api->copyMessage(array(
                         "chat_id" => $chat_id,
                         "from_chat_id" => $GLOBALS["TG_DUMP_CHANNEL_ID"],
                         "disable_notification" => True,


### PR DESCRIPTION
Just changed "Forwardmessage" To "CopyMessage" Coz In Telegram bot Api V5.0 telegram introduced a new method "CopyMessage" insted of forward message. So we can send file without forward tag